### PR TITLE
feat(auth): implement role-based turf authorization middleware

### DIFF
--- a/client/app/(auth)/sign-up/page.tsx
+++ b/client/app/(auth)/sign-up/page.tsx
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import Link from "next/link";
-import { useForm } from "react-hook-form";
-import { Button } from "@/components/Button";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { toast } from "react-hot-toast";
-import {useAuth} from "@/lib/contexts/authContext";
+import { Button } from '@/components/Button';
+import { useAuth } from '@/lib/contexts/authContext';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
 
 interface SignUpFormData {
   first_name: string;
@@ -21,7 +21,7 @@ interface SignUpFormData {
 export default function SignUpPage() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
-  const {login}=useAuth();
+  const { login } = useAuth();
 
   const {
     register,
@@ -31,7 +31,7 @@ export default function SignUpPage() {
     reset,
   } = useForm<SignUpFormData>();
 
-  const password = watch("password");
+  const password = watch('password');
 
   const onSubmit = async (data: SignUpFormData) => {
     try {
@@ -40,35 +40,35 @@ export default function SignUpPage() {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/register`,
         {
-          method: "POST",
+          method: 'POST',
           headers: {
-            "Content-Type": "application/json",
+            'Content-Type': 'application/json',
           },
-          credentials: "include", // Important for cookies
+          credentials: 'include', // Important for cookies
           body: JSON.stringify({
             first_name: data.first_name,
             last_name: data.last_name,
             email: data.email,
             password: data.password,
           }),
-        }
+        },
       );
 
       const result = await response.json();
 
       if (!response.ok) {
-        throw new Error(result.message || "Something went wrong");
+        throw new Error(result.message || 'Something went wrong');
       }
 
       // Login user after successful registration
       await login(data.email, data.password);
 
       // Successfully registered
-      toast.success("Registration successful!");
+      toast.success('Registration successful!');
       reset(); // Clear form
-      router.push("/"); // Redirect to login page
+      router.push('/'); // Redirect to login page
     } catch (error: any) {
-      toast.error(error.message || "Failed to register");
+      toast.error(error.message || 'Failed to register');
     } finally {
       setIsLoading(false);
     }
@@ -104,9 +104,9 @@ export default function SignUpPage() {
               <input
                 type="text"
                 id="first_name"
-                {...register("first_name", {
-                  required: "First name is required",
-                  minLength: { value: 2, message: "First name is too short" },
+                {...register('first_name', {
+                  required: 'First name is required',
+                  minLength: { value: 2, message: 'First name is too short' },
                 })}
                 className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 shadow-sm"
                 placeholder="Enter your first name"
@@ -129,9 +129,9 @@ export default function SignUpPage() {
               <input
                 type="text"
                 id="last_name"
-                {...register("last_name", {
-                  required: "Last name is required",
-                  minLength: { value: 2, message: "Last name is too short" },
+                {...register('last_name', {
+                  required: 'Last name is required',
+                  minLength: { value: 2, message: 'Last name is too short' },
                 })}
                 className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 shadow-sm"
                 placeholder="Enter your last name"
@@ -154,11 +154,11 @@ export default function SignUpPage() {
               <input
                 type="email"
                 id="email"
-                {...register("email", {
-                  required: "Email is required",
+                {...register('email', {
+                  required: 'Email is required',
                   pattern: {
                     value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                    message: "Invalid email address",
+                    message: 'Invalid email address',
                   },
                 })}
                 className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 shadow-sm"
@@ -182,11 +182,11 @@ export default function SignUpPage() {
               <input
                 type="password"
                 id="password"
-                {...register("password", {
-                  required: "Password is required",
+                {...register('password', {
+                  required: 'Password is required',
                   minLength: {
                     value: 8,
-                    message: "Password must be at least 8 characters",
+                    message: 'Password must be at least 8 characters',
                   },
                 })}
                 className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 shadow-sm"
@@ -210,10 +210,10 @@ export default function SignUpPage() {
               <input
                 type="password"
                 id="retypePassword"
-                {...register("retypePassword", {
-                  required: "Please retype your password",
-                  validate: (value) =>
-                    value === password || "Passwords do not match",
+                {...register('retypePassword', {
+                  required: 'Please retype your password',
+                  validate: value =>
+                    value === password || 'Passwords do not match',
                 })}
                 className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 shadow-sm"
                 placeholder="Re-type your password"
@@ -230,18 +230,18 @@ export default function SignUpPage() {
               <input
                 type="checkbox"
                 id="terms"
-                {...register("terms", { required: true })}
+                {...register('terms', { required: true })}
                 className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
               />
               <label htmlFor="terms" className="ml-2 text-sm text-gray-600">
-                I agree to the{" "}
+                I agree to the{' '}
                 <Link
                   href="/terms"
                   className="font-medium hover:text-green-700 underline"
                 >
                   Terms & Conditions
-                </Link>{" "}
-                and{" "}
+                </Link>{' '}
+                and{' '}
                 <Link
                   href="/privacy"
                   className="font-medium hover:text-green-700 underline"
@@ -263,13 +263,13 @@ export default function SignUpPage() {
               className="w-full"
               disabled={isLoading}
             >
-              {isLoading ? "Creating Account..." : "Create Account"}
+              {isLoading ? 'Creating Account...' : 'Create Account'}
             </Button>
           </form>
 
           {/* Footer Link */}
           <p className="mt-6 text-center text-sm text-gray-600">
-            Already have an account?{" "}
+            Already have an account?{' '}
             <Link
               href="/sign-in"
               className="text-gray-600 font-medium hover:text-green-700 underline"

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,10 +1,10 @@
-import Hero from "@/components/Hero";
-import {FeatureSection} from '@/components/FeatureSection'
+import { FeatureSection } from '@/components/FeatureSection';
+import Hero from '@/components/Hero';
 export default function Home() {
   return (
     <div>
       <Hero />
-      <FeatureSection/>
+      <FeatureSection />
     </div>
   );
 }

--- a/server/modules/auth/auth.middleware.ts
+++ b/server/modules/auth/auth.middleware.ts
@@ -102,10 +102,7 @@ export const authorizeTurfRoles = (action: string) => {
       );
       if (!userRoleEntry) {
         return next(
-          new ErrorResponse(
-            `User is not assigned a role in this bootcamp`,
-            403,
-          ),
+          new ErrorResponse(`User is not assigned a role in this turf`, 403),
         );
       }
       // Get permissible roles for the action

--- a/server/modules/auth/auth.route.ts
+++ b/server/modules/auth/auth.route.ts
@@ -1,26 +1,26 @@
-import express from "express";
+import express from 'express';
 import {
-  login,
-  register,
-  logout,
-  getMe,
   forgotPassword,
+  getMe,
+  login,
+  logout,
+  register,
   resetPassword,
-} from "./auth.controller";
-import { protect } from "./auth.middleware";
+} from './auth.controller';
+import { protect } from './auth.middleware';
 
 const router = express.Router();
 
-router.post("/register", register);
+router.post('/register', register);
 
-router.post("/login", login);
+router.post('/login', login);
 
-router.post("/logout", logout);
+router.post('/logout', logout);
 
-router.get("/me", protect, getMe);
+router.get('/me', protect, getMe);
 
-router.post("/forgot-password", forgotPassword);
+router.post('/forgot-password', forgotPassword);
 
-router.post("/reset-password", resetPassword);
+router.post('/reset-password', resetPassword);
 
 export default router;

--- a/server/modules/turf/tuf.route.ts
+++ b/server/modules/turf/tuf.route.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { authorize, protect } from '../auth/auth.middleware';
+import { createTurf } from './turf.controller';
+
+const router = express.Router();
+
+router.route('/').post(protect, authorize('owner'), createTurf);
+export default router;

--- a/server/modules/turf/tuf.route.ts
+++ b/server/modules/turf/tuf.route.ts
@@ -1,8 +1,31 @@
 import express from 'express';
-import { authorize, protect } from '../auth/auth.middleware';
-import { createTurf } from './turf.controller';
+import {
+  authorize,
+  authorizeTurfRoles,
+  protect,
+} from '../auth/auth.middleware';
+import {
+  addUserToTurf,
+  createTurf,
+  updateTurf,
+  updateTurfPermissions,
+} from './turf.controller';
 
 const router = express.Router();
 
 router.route('/').post(protect, authorize('owner'), createTurf);
+
+router.route('/:id').put(protect, authorizeTurfRoles('update'), updateTurf);
+
+router
+  .route('/:id/assign')
+  .put(protect, authorizeTurfRoles('roleManage'), addUserToTurf);
+
+router.put(
+  '/:id/permissions',
+  protect,
+  authorizeTurfRoles('roleManage'), // Only owners can modify permissions
+  updateTurfPermissions,
+);
+
 export default router;

--- a/server/modules/turf/turf.controller.ts
+++ b/server/modules/turf/turf.controller.ts
@@ -198,7 +198,7 @@ export const updateTurfPermissions = asyncHandler(
 
         // Validate roles
         const validRoles = roles.every(role =>
-          ['owner', 'manager', 'stuff'].includes(role),
+          ['owner', 'manager', 'staff'].includes(role),
         );
         if (!validRoles) {
           return next(

--- a/server/modules/turf/turf.controller.ts
+++ b/server/modules/turf/turf.controller.ts
@@ -1,0 +1,37 @@
+import { NextFunction, Request, Response } from 'express';
+import asyncHandler from '../../shared/middleware/async';
+import Turf from './turf.model';
+
+// @desc   Create new turf
+// @route  POST /api/v1/turf
+// @access Private
+export const createTurf = asyncHandler(
+  async (
+    req: Request & { user?: { id: string } },
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const turfData = {
+      ...req.body,
+      owner: req.user?.id,
+      userRoles: [
+        {
+          user: req.user?.id,
+          role: 'owner' as const,
+        },
+      ],
+      permissions: new Map([
+        ['roleManage', ['owner']],
+        ['update', ['owner']],
+        ['delete', ['owner']],
+      ]),
+    };
+
+    const turf = await Turf.create(turfData);
+
+    res.status(201).json({
+      success: true,
+      data: turf,
+    });
+  },
+);

--- a/server/modules/turf/turf.controller.ts
+++ b/server/modules/turf/turf.controller.ts
@@ -1,6 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 import asyncHandler from '../../shared/middleware/async';
+import ErrorResponse from '../../utils/errorResponse';
+import User from '../user/user.model';
 import Turf from './turf.model';
+
+import mongoose from 'mongoose';
 
 // @desc   Create new turf
 // @route  POST /api/v1/turf
@@ -33,5 +37,213 @@ export const createTurf = asyncHandler(
       success: true,
       data: turf,
     });
+  },
+);
+
+// @desc   Create new turf
+// @route  PUT /api/v1/turf
+// @access Private
+export const updateTurf = asyncHandler(
+  async (
+    req: Request & { user?: { id: string } },
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const turf = await Turf.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!turf) {
+      return next(
+        new ErrorResponse(`response not found for id ${req.params.id}`, 404),
+      );
+    }
+
+    res.status(200).json({
+      success: true,
+      data: turf,
+    });
+  },
+);
+
+// @desc Post adds an user in his turf with assigning a role
+// @route POST/api/v1/turf/:id/assign
+// @private
+
+export const addUserToTurf = asyncHandler(
+  async (
+    req: Request & { user?: { id: string } },
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const { userId, role } = req.body;
+
+    if (!userId || !role) {
+      next(new ErrorResponse('Please provide both userId and role', 400));
+    }
+    try {
+      // First check if both user and bootcamp exist
+      const [userToAdd, turf] = await Promise.all([
+        User.findById(userId),
+        Turf.findById(req.params.id),
+      ]);
+      if (!userToAdd) {
+        return next(
+          new ErrorResponse(`User with ID ${userId} was not found`, 404),
+        );
+      }
+
+      if (!turf) {
+        return next(
+          new ErrorResponse(`Turf with ID ${req.params.id} was not found`, 404),
+        );
+      }
+      // Check for existing role
+      const existingRole = turf.userRoles.find(
+        userRole => userRole.user.toString() === userId.toString(),
+      );
+      if (existingRole) {
+        return next(
+          new ErrorResponse(
+            `User with ID ${userId} is already assigned to this turf with role: ${existingRole.role}`,
+            400,
+          ),
+        );
+      }
+      // Instead of using save(), use findByIdAndUpdate
+      const updatedTurf = await Turf.findByIdAndUpdate(
+        req.params.id,
+        {
+          $push: {
+            userRoles: { user: userId, role: role },
+          },
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+      if (!updatedTurf) {
+        return next(new ErrorResponse('No turf found to update', 404));
+      }
+
+      res.status(200).json({
+        success: true,
+        data: updatedTurf.userRoles,
+      });
+    } catch (error: unknown) {
+      console.error('Update Error:', error);
+
+      if (error instanceof mongoose.Error.ValidationError) {
+        return next(
+          new ErrorResponse(`Validation Error: ${error.message}`, 400),
+        );
+      }
+
+      if (error instanceof Error) {
+        return next(new ErrorResponse(error.message, 500));
+      }
+
+      return next(new ErrorResponse('Server error', 500));
+    }
+  },
+);
+
+// @desc    Update turf permissions
+// @route   PUT /api/v1/turf/:id/permissions
+// @access  Private (Only owner)
+export const updateTurfPermissions = asyncHandler(
+  async (
+    req: Request & { user?: { id: string } },
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const { permissions } = req.body;
+    const turfId = req.params.id;
+
+    // Validate input
+    if (!permissions || typeof permissions !== 'object') {
+      return next(
+        new ErrorResponse('Please provide valid permissions object', 400),
+      );
+    }
+
+    try {
+      // Find turf
+      const turf = await Turf.findById(turfId);
+
+      if (!turf) {
+        return next(
+          new ErrorResponse(`Turf not found with id of ${turfId}`, 404),
+        );
+      }
+
+      // Verify ownership
+      if (turf.owner.toString() !== req.user?.id) {
+        return next(
+          new ErrorResponse('Not authorized to update permissions', 401),
+        );
+      }
+
+      // Convert permissions object to Map
+      const permissionsMap = new Map<string, string[]>();
+
+      // Validate and process each permission
+      for (const [action, roles] of Object.entries(permissions)) {
+        if (!Array.isArray(roles)) {
+          return next(
+            new ErrorResponse(`Roles for ${action} must be an array`, 400),
+          );
+        }
+
+        // Validate roles
+        const validRoles = roles.every(role =>
+          ['owner', 'manager', 'stuff'].includes(role),
+        );
+        if (!validRoles) {
+          return next(
+            new ErrorResponse(
+              'Invalid role specified. Roles must be either owner or editor',
+              400,
+            ),
+          );
+        }
+
+        permissionsMap.set(action, roles);
+      }
+
+      // Update turf permissions
+      const updatedTurf = await Turf.findByIdAndUpdate(
+        turfId,
+        { permissions: Object.fromEntries(permissionsMap) }, // Convert Map to plain object
+        {
+          new: true,
+          runValidators: true,
+        },
+      ).select('permissions');
+
+      if (!updatedTurf) {
+        return next(new ErrorResponse('Turf update failed', 500));
+      }
+
+      res.status(200).json({
+        success: true,
+        data: updatedTurf.permissions,
+      });
+    } catch (error: unknown) {
+      console.error('Permission Update Error:', error);
+
+      if (error instanceof mongoose.Error.ValidationError) {
+        return next(
+          new ErrorResponse(`Validation Error: ${error.message}`, 400),
+        );
+      }
+
+      if (error instanceof Error) {
+        return next(new ErrorResponse(error.message, 500));
+      }
+
+      return next(new ErrorResponse('Server error', 500));
+    }
   },
 );

--- a/server/modules/turf/turf.model.ts
+++ b/server/modules/turf/turf.model.ts
@@ -26,7 +26,7 @@ interface ITurf extends mongoose.Document {
   owner: mongoose.Types.ObjectId;
   userRoles: Array<{
     user: mongoose.Types.ObjectId;
-    role: 'owner' | 'manager' | 'stuff';
+    role: 'owner' | 'manager' | 'staff';
   }>;
   permissions: Map<string, string[]>;
   createdAt: Date;
@@ -86,7 +86,7 @@ const TurfSchema = new mongoose.Schema<ITurf>({
       },
       role: {
         type: String,
-        enum: ['owner', 'manager', 'stuff'],
+        enum: ['owner', 'manager', 'staff'],
         required: true,
       },
     },

--- a/server/modules/turf/turf.model.ts
+++ b/server/modules/turf/turf.model.ts
@@ -1,0 +1,140 @@
+import mongoose from 'mongoose';
+import slugify from 'slugify';
+import geocoder from '../../utils/nodeGeocoder';
+
+// Interface for Turf Location
+interface ILocation {
+  type: string;
+  coordinates: [number, number];
+  formattedAddress?: string;
+  street?: string;
+  city?: string;
+  zipcode?: string;
+  country?: string;
+}
+
+// Interface for Turf Document
+interface ITurf extends mongoose.Document {
+  name: string;
+  slug: string;
+  description: string;
+
+  phone?: string;
+
+  address: string;
+  location?: ILocation;
+  owner: mongoose.Types.ObjectId;
+  userRoles: Array<{
+    user: mongoose.Types.ObjectId;
+    role: 'owner' | 'manager' | 'stuff';
+  }>;
+  permissions: Map<string, string[]>;
+  createdAt: Date;
+}
+
+// Turf Schema Definition
+const TurfSchema = new mongoose.Schema<ITurf>({
+  name: {
+    type: String,
+    required: [true, 'Please add a name'],
+    unique: true,
+    trim: true,
+    maxlength: [50, 'Name cannot exceed 50 characters'],
+  },
+  slug: String,
+  description: {
+    type: String,
+    required: [true, 'Please add a description'],
+    maxlength: [500, 'Description cannot exceed 500 characters'],
+  },
+
+  phone: {
+    type: String,
+    maxlength: [20, 'Phone number cannot exceed 20 characters'],
+  },
+
+  address: {
+    type: String,
+    required: [true, 'Please add an address'],
+  },
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'],
+    },
+    coordinates: {
+      type: [Number],
+      index: '2dsphere',
+    },
+    formattedAddress: String,
+    street: String,
+    city: String,
+    zipcode: String,
+    country: String,
+  },
+  owner: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  userRoles: [
+    {
+      user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+        required: true,
+      },
+      role: {
+        type: String,
+        enum: ['owner', 'manager', 'stuff'],
+        required: true,
+      },
+    },
+  ],
+  permissions: {
+    type: Map,
+    of: [String],
+    default: () => new Map(),
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+// Generate slug from name
+TurfSchema.pre<ITurf>('save', function (next) {
+  this.slug = slugify(this.name, { lower: true });
+  next();
+});
+
+// Create location from address
+TurfSchema.pre<ITurf>('save', async function (next) {
+  try {
+    const loc = await geocoder.geocode(this.address);
+    if (loc.length === 0 || !loc[0].longitude || !loc[0].latitude) {
+      throw new Error('Invalid address or coordinates not found');
+    }
+
+    this.location = {
+      type: 'Point',
+      coordinates: [loc[0].longitude, loc[0].latitude] as [number, number],
+      formattedAddress: loc[0].formattedAddress,
+      street: loc[0].streetName,
+      city: loc[0].city,
+      zipcode: loc[0].zipcode,
+      country: loc[0].countryCode,
+    };
+
+    // Remove original address from DB
+    // @ts-ignore: Intentionally removing required field after processing
+    this.address = undefined;
+    next();
+  } catch (err) {
+    next(err as Error);
+  }
+});
+
+const Turf = mongoose.model<ITurf>('Turf', TurfSchema);
+
+export default Turf;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,8 +20,10 @@
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.9.6",
+        "node-geocoder": "^4.4.1",
         "nodemailer": "^6.10.0",
         "nodemon": "^3.1.9",
+        "slugify": "^1.6.6",
         "typescript": "^5.7.3",
         "validator": "^13.12.0"
       },
@@ -30,6 +32,7 @@
         "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
         "@types/jsonwebtoken": "^9.0.8",
+        "@types/node-geocoder": "^4.2.6",
         "@types/nodemailer": "^6.4.17",
         "@types/validator": "^13.12.2",
         "concurrently": "^9.1.2",
@@ -160,6 +163,26 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-geocoder": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@types/node-geocoder/-/node-geocoder-4.2.6.tgz",
+      "integrity": "sha512-rONIqFylsxAeyqCpfy626vs9ofNI8oXjNyBS2KuI+ePbCyLGrcqkVSrhIvuKxfeXtqikGk118EZtjehU0cUH9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/node-fetch": "^2"
+      }
+    },
     "node_modules/@types/nodemailer": {
       "version": "6.4.17",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
@@ -274,6 +297,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -294,6 +323,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -536,6 +570,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -677,6 +723,15 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -897,6 +952,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1522,6 +1591,56 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-geocoder": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/node-geocoder/-/node-geocoder-4.4.1.tgz",
+      "integrity": "sha512-krx50Gxl4yBgMBhfUhOuNwStzLi+gAYaa46gs0e+ftTvaqLsjKYDFVxC8ff6RLc2f11Gp7Y+R1mkzwsE2c0chw==",
+      "dependencies": {
+        "bluebird": "^3.5.2",
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
@@ -1999,6 +2118,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sparse-bitfield": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,8 +26,10 @@
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.9.6",
+    "node-geocoder": "^4.4.1",
     "nodemailer": "^6.10.0",
     "nodemon": "^3.1.9",
+    "slugify": "^1.6.6",
     "typescript": "^5.7.3",
     "validator": "^13.12.0"
   },
@@ -36,6 +38,7 @@
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
     "@types/jsonwebtoken": "^9.0.8",
+    "@types/node-geocoder": "^4.2.6",
     "@types/nodemailer": "^6.4.17",
     "@types/validator": "^13.12.2",
     "concurrently": "^9.1.2",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,11 +1,12 @@
-import express, { Request, Response } from "express";
-import ExpressMongoSanitize from "express-mongo-sanitize";
-import helmet from "helmet";
-import cors from "cors";
-import cookieParser from "cookie-parser";
-import connectDB from "./config/db";
-import authRouter from "./modules/auth/auth.route";
-import errorHandler from "./shared/middleware/error";
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
+import express, { Request, Response } from 'express';
+import ExpressMongoSanitize from 'express-mongo-sanitize';
+import helmet from 'helmet';
+import connectDB from './config/db';
+import authRouter from './modules/auth/auth.route';
+import turfRouter from './modules/turf/tuf.route';
+import errorHandler from './shared/middleware/error';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -18,17 +19,18 @@ app.use(ExpressMongoSanitize());
 app.use(helmet());
 app.use(
   cors({
-    origin: process.env.CLIENT_URL || "http://localhost:3000",
+    origin: process.env.CLIENT_URL || 'http://localhost:3001',
     credentials: true, // Important for cookies
-    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-  })
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  }),
 );
 
-app.get("/", (req: Request, res: Response) => {
-  res.send("Server is running");
+app.get('/', (req: Request, res: Response) => {
+  res.send('Server is running');
 });
 
-app.use("/api/v1/auth", authRouter);
+app.use('/api/v1/auth', authRouter);
+app.use('/api/v1/turf', turfRouter);
 
 app.use(errorHandler);
 app.listen(port, () => console.log(`Server app listening on port ${port}!`));

--- a/server/utils/nodeGeocoder.ts
+++ b/server/utils/nodeGeocoder.ts
@@ -1,0 +1,11 @@
+import NodeGeocoder from 'node-geocoder';
+
+const options: NodeGeocoder.Options = {
+  provider: 'openstreetmap',
+  // No apiKey needed for OpenStreetMap
+  formatter: null, // 'gpx', 'string', ...
+};
+
+const geocoder = NodeGeocoder(options);
+
+export default geocoder;


### PR DESCRIPTION
- Add authorizeTurfRoles middleware for fine-grained permission control
- Implement permission checks based on turf roles
- Add type safety for auth requests and JWT payload
- Update turf model to support role-based permissions
- Fix error handling in auth middleware
- Integrate permission system with turf controllers